### PR TITLE
Remove Markdown sanitization; sanitize HTML output only

### DIFF
--- a/core/constants.js
+++ b/core/constants.js
@@ -67,7 +67,7 @@ module.exports = {
   SPECIAL_POST_TYPE_HIDDEN,
   SPECIAL_POST_TYPES,
   REQUIRED_ARTICLES: ['docs', 'faq'],
-  ALLOWED_POST_TAGS: ['b', 'i', 'em', 'strong', 'a', 'u', 'br', 'iframe', 'img', 'p', 'video', 'source'],
+  ALLOWED_POST_TAGS: ['b', 'i', 'em', 'strong', 'a', 'u', 'code', 'br', 'hr', 'iframe', 'img', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'blockquote', 'pre', 'ul', 'ol', 'li', 'video', 'source'],
   ALLOWED_POST_ATTRIBUTES: {
     'p': ['class'],
     'a': ['href', 'class', 'name'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1953,11 +1953,6 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
       "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
     },
-    "cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
-    },
     "cycle": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
@@ -3248,7 +3243,8 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -9659,15 +9655,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "xss": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-0.3.7.tgz",
-      "integrity": "sha512-jq7Wo30jFf4hHBG6GIIbdmY/COjd9M7MA5Jz+jt822qePKsFXtDUYqNTDRMJo51vvuh0VEZCtFiuRDonFZWL1g==",
-      "requires": {
-        "commander": "2.14.1",
-        "cssfilter": "0.0.10"
-      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
     "validator": "^7.0.0",
     "webpack": "^4.3.0",
     "webpack-merge": "^4.1.1",
-    "winston": "^2.3.0",
-    "xss": "^0.3.3"
+    "winston": "^2.3.0"
   },
   "optionalDependencies": {
     "sharp": "^0.17.3"


### PR DESCRIPTION
Trying to sanitize Markdown (using `sanitize-markdown` or anything else)
in such a way that it produces safe HTML, without mangling perfectly
safe Markdown documents, is difficult. #182 is just one example; the
hack to re-instate `>` characters for blockquotes is another.

Moreover, we were already sanitizing the HTML output, albeit with the
`xss` library. All it takes is allowing the HTML tags that are produced
by Markdown itself.

Fixes #182.

Please check that I didn't overlook any tags or attributes that we want to allow!