### PR TITLE
Change `/events` links into `/explore/events`

### DIFF
--- a/server/docs/article-data/akj-tournament-rules.md
+++ b/server/docs/article-data/akj-tournament-rules.md
@@ -11,7 +11,7 @@ On each game, players are awarded a number of points for being in the top 10, as
 
 ![](https://i.imgur.com/CvSqPvV.jpg)
 
-Look for tournaments in the [events history page](/events#other_events) to see how things work, who are the title holders... and when the next one is due! :)
+Look for tournaments in the [events history page](/explore/events) to see how things work, who are the title holders... and when the next one is due! :)
 
 ## We need your games!
 You might be wondering, _how do I get my game in there?_ If you've submitted a game on *Alakajam!* which has high scores and might be suitable, make sure you have ticked the **"Allow use for tournaments"** checkbox in your entry. To attract the attention of the hosts to your game, you can also [fill out this form](https://docs.google.com/forms/d/e/1FAIpQLSee7pb1iBkJPVYkQfGsn1rMjzW4o7WrVAzoE_Q5bWPcio0_uw/viewform).

--- a/server/docs/article-data/welcome.md
+++ b/server/docs/article-data/welcome.md
@@ -6,7 +6,7 @@ Welcome!
 * **Kajam!** month-long events, inviting people to learn and experiment around a specific topic.
 * And finally **Tournaments** where everyone can compete on the games we made!
 
-Sounds exciting? Come join us! You can start by making an account [in a few clicks](/register), then check the home page or the [Events](/events) to learn the date of the next jam. Feel free to introduce yourself [with a blog post](/post/create)!
+Sounds exciting? Come join us! You can start by making an account [in a few clicks](/register), then check the home page or the [Events](/explore/events) to learn the date of the next jam. Feel free to introduce yourself [with a blog post](/post/create)!
 
 If you want to give a hand to our little community, check the [contributing page](/article/about/contributing).
 


### PR DESCRIPTION
Those led to a page that just says `Cannot GET /events`, so I presume the endpoint for events has changed from `/events` to `/explore/events` over the years
On a sidenote, is there no proper 404 page?