### PR TITLE
Fix entry API when it has no pictures

### DIFF
--- a/server/entry/entry.service.ts
+++ b/server/entry/entry.service.ts
@@ -33,7 +33,7 @@ export class EntryService {
       name: "untitled",
       title: "",
       comment_count: 0,
-      pictures: "{previews: []}",
+      pictures: {previews: []},
     }) as EntryBookshelfModel;
 
     if (event) {


### PR DESCRIPTION
The JSON here should be an object, but is hardcoded as a string. [Example](https://alakajam.com/api/entry/1624).